### PR TITLE
Command cancellation decorator

### DIFF
--- a/src/Shipwright.Commands.Test/Decorators/CommandCancellationDecoratorTests.cs
+++ b/src/Shipwright.Commands.Test/Decorators/CommandCancellationDecoratorTests.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using Moq;
+using Xunit;
+
+namespace Shipwright.Commands.Decorators;
+
+public class CommandCancellationDecoratorTests
+{
+    readonly Mock<ICommandHandler<FakeCommand, Guid>> mockHandler = new( MockBehavior.Strict );
+    ICommandHandler<FakeCommand, Guid> handler;
+    ICommandHandler<FakeCommand, Guid> instance() => new CommandCancellationDecorator<FakeCommand, Guid>( handler );
+
+    protected CommandCancellationDecoratorTests()
+    {
+        handler = mockHandler.Object;
+    }
+
+    public class Constructor : CommandCancellationDecoratorTests
+    {
+        [Fact]
+        public void requires_handler()
+        {
+            handler = null!;
+            Assert.Throws<ArgumentNullException>( nameof(handler), instance );
+        }
+    }
+
+    public class Execute : CommandCancellationDecoratorTests
+    {
+        FakeCommand command = new();
+        CancellationToken cancellationToken;
+        Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+        [Fact]
+        public async Task requires_command()
+        {
+            command = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(command), method );
+        }
+
+        [Fact]
+        public async Task throws_when_canceled()
+        {
+            cancellationToken = new( true );
+            await Assert.ThrowsAsync<OperationCanceledException>( method );
+        }
+
+        [Fact]
+        public async Task executes_handler_and_returns_result_when_not_canceled()
+        {
+            cancellationToken = new( false );
+
+            var expected = Guid.NewGuid();
+            mockHandler.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+            var actual = await method();
+            Assert.Equal( expected, actual );
+        }
+    }
+}

--- a/src/Shipwright.Commands/Decorators/CommandCancellationDecorator.cs
+++ b/src/Shipwright.Commands/Decorators/CommandCancellationDecorator.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+namespace Shipwright.Commands.Decorators;
+
+/// <summary>
+/// Decorates a command handler to check for cancellation before executing.
+/// </summary>
+/// <typeparam name="TCommand">Type of the commands whose handler is decorated.</typeparam>
+/// <typeparam name="TResult">Type returned by executing a command.</typeparam>
+public class CommandCancellationDecorator<TCommand, TResult> : ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+{
+    readonly ICommandHandler<TCommand, TResult> _handler;
+
+    public CommandCancellationDecorator( ICommandHandler<TCommand, TResult> handler )
+    {
+        _handler = handler ?? throw new ArgumentNullException( nameof(handler) );
+    }
+
+    public async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+    {
+        if ( command == null ) throw new ArgumentNullException( nameof(command) );
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _handler.Execute( command, cancellationToken );
+    }
+}


### PR DESCRIPTION
# Problem
As a developer, I want to check for cancellation prior to executing any command.

# Solution
Added a decorator that checks the cancellation token before executing the decorated handler.