### PR TITLE
Command validation decorator

### DIFF
--- a/src/Shipwright.Commands.Test/Decorators/CommandValidationDecoratorTests.cs
+++ b/src/Shipwright.Commands.Test/Decorators/CommandValidationDecoratorTests.cs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using AutoFixture;
+using FluentValidation;
+using FluentValidation.Results;
+using Moq;
+using Xunit;
+
+namespace Shipwright.Commands.Decorators;
+
+public class CommandValidationDecoratorTests
+{
+    readonly Mock<ICommandHandler<FakeCommand, Guid>> mockHandler = new( MockBehavior.Strict );
+    readonly Mock<IValidator<FakeCommand>> mockValidator = new( MockBehavior.Strict );
+    ICommandHandler<FakeCommand, Guid> handler;
+    IValidator<FakeCommand> validator;
+    ICommandHandler<FakeCommand, Guid> instance() => new CommandValidationDecorator<FakeCommand, Guid>( handler, validator );
+
+    public CommandValidationDecoratorTests()
+    {
+        handler = mockHandler.Object;
+        validator = mockValidator.Object;
+    }
+
+    public class Constructor : CommandValidationDecoratorTests
+    {
+        [Fact]
+        public void requires_handler()
+        {
+            handler = null!;
+            Assert.Throws<ArgumentNullException>( nameof(handler), instance );
+        }
+
+        [Fact]
+        public void requires_validator()
+        {
+            validator = null!;
+            Assert.Throws<ArgumentNullException>( nameof(validator), instance );
+        }
+    }
+
+    public class Execute : CommandValidationDecoratorTests
+    {
+        FakeCommand command = new();
+        CancellationToken cancellationToken;
+        Task<Guid> method() => instance().Execute( command, cancellationToken );
+
+        [Fact]
+        public async Task requires_command()
+        {
+            command = null!;
+            await Assert.ThrowsAsync<ArgumentNullException>( nameof(command), method );
+        }
+
+        [Theory]
+        [InlineData( true )]
+        [InlineData( false )]
+        public async Task throws_when_validation_fails( bool canceled )
+        {
+            cancellationToken = new( canceled );
+
+            var errors = new Fixture().CreateMany<ValidationFailure>().ToArray();
+            var result = new ValidationResult( errors );
+            mockValidator.Setup( _ => _.ValidateAsync( command, cancellationToken ) ).ReturnsAsync( result );
+
+            var ex = await Assert.ThrowsAsync<ValidationException>( method );
+            Assert.Equal( errors, ex.Errors );
+        }
+
+        [Theory]
+        [InlineData( true )]
+        [InlineData( false )]
+        public async Task executes_handler_and_returns_result_when_valid( bool canceled )
+        {
+            cancellationToken = new( canceled );
+            var errors = Array.Empty<ValidationFailure>();
+            var result = new ValidationResult( errors );
+            mockValidator.Setup( _ => _.ValidateAsync( command, cancellationToken ) ).ReturnsAsync( result );
+
+            var expected = Guid.NewGuid();
+            mockHandler.Setup( _ => _.Execute( command, cancellationToken ) ).ReturnsAsync( expected );
+
+            var actual = await method();
+            Assert.Equal( expected, actual );
+        }
+    }
+}

--- a/src/Shipwright.Commands.Test/Shipwright.Commands.Test.csproj
+++ b/src/Shipwright.Commands.Test/Shipwright.Commands.Test.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Shipwright.Commands/Decorators/CommandValidationDecorator.cs
+++ b/src/Shipwright.Commands/Decorators/CommandValidationDecorator.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) TTCO Holding Company, Inc. and Contributors
+// Licensed under the Apache License, Version 2.0
+// See https://opensource.org/licenses/Apache-2.0 or the LICENSE file in the repository root for the full text of the license.
+
+using FluentValidation;
+
+namespace Shipwright.Commands.Decorators;
+
+/// <summary>
+/// Decorates a command handler to validate a command before executing.
+/// </summary>
+/// <typeparam name="TCommand">Type of the commands whose handler is decorated.</typeparam>
+/// <typeparam name="TResult">Type returned by executing a command.</typeparam>
+public class CommandValidationDecorator<TCommand, TResult> : ICommandHandler<TCommand, TResult> where TCommand : Command<TResult>
+{
+    readonly ICommandHandler<TCommand, TResult> _handler;
+    readonly IValidator<TCommand> _validator;
+
+    public CommandValidationDecorator( ICommandHandler<TCommand, TResult> handler, IValidator<TCommand> validator )
+    {
+        _handler = handler ?? throw new ArgumentNullException( nameof(handler) );
+        _validator = validator ?? throw new ArgumentNullException( nameof(validator) );
+    }
+
+    public async Task<TResult> Execute( TCommand command, CancellationToken cancellationToken )
+    {
+        if ( command == null ) throw new ArgumentNullException( nameof(command) );
+
+        var result = await _validator.ValidateAsync( command, cancellationToken );
+
+        if ( !result.IsValid )
+            throw new ValidationException( $"Failed to validate command of type {typeof(TCommand)}", result.Errors );
+
+        return await _handler.Execute( command, cancellationToken );
+    }
+}

--- a/src/Shipwright.Commands/Shipwright.Commands.csproj
+++ b/src/Shipwright.Commands/Shipwright.Commands.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="10.*" />
     <PackageReference Include="Lamar" Version="8.*" />
   </ItemGroup>
 


### PR DESCRIPTION
# Problem
As a developer, I want to validate commands prior to executing them.

# Solution
Added a decorator that uses FluentValidation to validate a command prior to executing the command handler. As a consequence, all commands now require a validator.